### PR TITLE
Break tick loop if message waiting

### DIFF
--- a/mortise.py
+++ b/mortise.py
@@ -543,6 +543,7 @@ class StateMachine:
                             self._log_fn(str(e))
                         # Set our current state to the next state
                         self._transition(next_state)
+                fsm_busy = fsm_busy and self._msg_queue.empty()
             except (StateRetryLimitError, StateTimedOut) as e:
                 self._msg_queue.put(e)
                 break


### PR DESCRIPTION
The continual ticking was added so states could not be message dependent and continue moving on but in these states we are missing messages. Reflects change made in other code base where it was tested. 

@keyme/robotics 