### PR TITLE
Add testing class for easily testing state transitions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,19 @@
+from mortise.mortise import *
+
+__all__ = [
+    StateRetryLimitError,
+    StateMachineComplete,
+    MissingOnStateHandler,
+    StateTimedOut,
+    InvalidPushError,
+    EmptyStateStackError,
+    NoPushedStatesError,
+    Push,
+    Pop,
+    state_name,
+    base_state_name,
+    State,
+    DefaultStates,
+    GenericCommon,
+    SharedState,
+    StateMachine]

--- a/examples/testing_example.py
+++ b/examples/testing_example.py
@@ -1,0 +1,140 @@
+import mortise
+import mortise.testing as testing_mortise
+
+# Can be run with any testing framework that uses unittest
+
+
+class FirstState(mortise.State):
+    def on_state(self, st):
+        return NextState
+
+
+class NextState: pass
+
+
+class FirstState2(mortise.State):
+    def on_state(self, st):
+        if st.common.cool:
+            return CoolState
+        else:
+            return HotState
+
+
+class CoolState: pass
+class HotState: pass
+
+
+class LoopState(mortise.State):
+    def on_state(self, st):
+        if st.common.num < 5:
+            st.common.num += 1
+            return None
+        else:
+            return LoopDoneState
+
+
+class LoopDoneState: pass
+
+
+class TimeoutState(mortise.State):
+    def on_state(self, st):
+        raise mortise.StateTimedOut
+
+    def on_timeout(self, st):
+        return TimedOutState
+
+
+class TimedOutState: pass
+
+
+class RetryLimitState(mortise.State):
+    def on_state(self, st):
+        raise mortise.StateRetryLimitError
+
+    def on_timeout(self, st):
+        return TimedOutState
+
+    def on_fail(self, st):
+        return FailedState
+
+
+class FailedState: pass
+
+
+class ErrorState(mortise.State):
+    def on_state(self, st):
+        pass
+
+    def on_timeout(self, st):
+        return TimedOutState
+
+    def on_fail(self, st):
+        return FailedState
+
+
+class MsgState(mortise.State):
+    def on_state(self, st):
+        if st.msg is None:
+            return
+        elif st.msg and st.msg == "good":
+            return GoodState
+        else:
+            return BadState
+
+
+class GoodState: pass
+class BadState: pass
+
+
+class NoneState(mortise.State):
+    def on_state(self, st):
+        return None
+
+
+class OnEnterState(mortise.State):
+    def on_enter(self, st):
+        self.entered = True
+
+    def on_state(self, st):
+        if self.entered:
+            return NextState
+        else:
+            return FirstState
+
+
+class TestMortise(testing_mortise.MortiseTest):
+    def testFirstToNext(self):
+        self.assertNextState(FirstState, NextState)
+
+    def testFirstState2CoolToCool(self):
+        self.assertNextState(FirstState2, CoolState, {"cool": True})
+
+    def testFirstState2CoolToHot(self):
+        self.assertNextState(FirstState2, HotState, {"cool": False})
+
+    def testLoopStateFinishes(self):
+        self.assertNextState(LoopState, LoopDoneState, {"num": 0})
+
+    def testTimeoutStateTimesOut(self):
+        self.assertNextState(TimeoutState, TimedOutState)
+
+    def testFailStateFails(self):
+        self.assertNextState(RetryLimitState, FailedState)
+
+    def testErrorStateToTimedOut(self):
+        self.assertTimedOutState(ErrorState, TimedOutState)
+
+    def testErrorStateToFailed(self):
+        self.assertFailState(ErrorState, FailedState)
+
+    def testMsgToGood(self):
+        self.assertNextState(MsgState, GoodState, msg="good")
+
+    def testMsgToBad(self):
+        self.assertNextState(MsgState, BadState, msg="bad")
+
+    def testNoTransition(self):
+        self.assertNoTransition(NoneState)
+
+    def testOnEnter(self):
+        self.assertNextState(OnEnterState, NextState)

--- a/testing.py
+++ b/testing.py
@@ -1,0 +1,69 @@
+import mortise
+import unittest
+
+
+class FakeCommon:
+    def __init__(self, entries):
+        self.__dict__.update(**entries)
+
+
+class FakeFSM:
+    def __init__(self, init_state):
+        self.msg = None
+        if isinstance(init_state, dict):
+            self.common = FakeCommon(init_state)
+        else:
+            self.common = init_state
+
+
+def makeTestingInternalState(dictState):
+    """Takes a dictionary mirroring the internal state
+       a mortise State expects to see and creates that
+       object to be used in testing correct transisitions"""
+    return FakeFSM(dictState)
+
+
+class MortiseTest(unittest.TestCase):
+
+    def _next_state(self, fsm, state):
+        while True:
+            try:
+                result_state = state.tick(fsm)
+                if result_state is not None:
+                    break
+            except (mortise.StateRetryLimitError,
+                    mortise.StateTimedOut) as e:
+                fsm.msg = e
+        return result_state
+
+    def assertNextState(self, mortise_state, next_state,
+                        initial_state=None, msg=None):
+        current_state = mortise_state()
+        fake_fsm = FakeFSM(initial_state or {})
+        fake_fsm.msg = msg
+        result_state = self._next_state(fake_fsm, current_state)
+        self.assertIs(result_state, next_state)
+
+    def assertTimedOutState(self, mortise_state, next_state,
+                            initial_state=None):
+        self.assertNextState(mortise_state, next_state, initial_state,
+                             mortise.StateTimedOut())
+
+    def assertFailState(self, mortise_state, next_state, initial_state=None):
+        self.assertNextState(mortise_state, next_state, initial_state,
+                             mortise.StateRetryLimitError())
+
+    def _single_transition(self, mortise_state, initial_state=None, msg=None):
+        current_state = mortise_state()
+        fake_fsm = FakeFSM(initial_state or {})
+        fake_fsm.msg = msg
+        return current_state.tick(fake_fsm)
+
+    def assertNoTransition(self, mortise_state, initial_state=None, msg=None):
+        self.assertIsNone(
+            self._single_transition(mortise_state, initial_state, msg))
+
+    def assertSomeTransition(self, mortise_state, initial_state=None,
+                             msg=None):
+        self.assertIsNotNone(
+            self._single_transition(mortise_state, initial_state, msg))


### PR DESCRIPTION
Added a class that can inherit instead of unittest.TestCase (it inherits from unittest.TestCase) to give the user an easy interface to test state classes.

This adds assert methods to assert that a state class is returned after running a given state. It allows the user to supply the initial state for input to the state being tested as either a nested dictionary mirroring the object the state expects in st.common or as an instance of the actual object expected. The user can also supply the incoming msg to the state machine to test transactions triggered by msgs. For helpers there are also asserts that the correct state is returned when there is a time out or the retry limit has been reached. 

Also added a file that shows examples of how / when to use / tests that the testing framework works. 

The setup file seems to be working the way I want so after this PR gets merged I will see if I can get this on PyPi and make a PR into kiosk to move to using the package so I don't have to add these changes to that repo too. 

@keyme/robotics-engineers 