### PR TITLE
TESTS: Optionally run on_enter of the next state

### DIFF
--- a/examples/testing_example.py
+++ b/examples/testing_example.py
@@ -4,6 +4,11 @@ import mortise.testing as testing_mortise
 # Can be run with any testing framework that uses unittest
 
 
+class CommonState:
+    def __init__(self):
+        self.entered = False
+
+
 class FirstState(mortise.State):
     def on_state(self, st):
         return NextState
@@ -141,5 +146,8 @@ class TestMortise(testing_mortise.MortiseTest):
         self.assertNextState(OnEnterState, NextState)
 
     def testNextOnEnter(self):
-        self.assertNextState(OnEnterState, NextState, {"entered": True},
+        common_state = CommonState()
+        self.assertFalse(common_state.entered)
+        self.assertNextState(OnEnterState, NextState, common_state,
                              enter_next_state=True)
+        self.assertTrue(common_state.entered)

--- a/examples/testing_example.py
+++ b/examples/testing_example.py
@@ -9,8 +9,9 @@ class FirstState(mortise.State):
         return NextState
 
 
-class NextState: pass
-
+class NextState(mortise.State):
+    def on_enter(self, st):
+        st.common.entered = True
 
 class FirstState2(mortise.State):
     def on_state(self, st):
@@ -138,3 +139,7 @@ class TestMortise(testing_mortise.MortiseTest):
 
     def testOnEnter(self):
         self.assertNextState(OnEnterState, NextState)
+
+    def testNextOnEnter(self):
+        self.assertNextState(OnEnterState, NextState, {"entered": True},
+                             enter_next_state=True)

--- a/mortise/testing.py
+++ b/mortise/testing.py
@@ -37,12 +37,16 @@ class MortiseTest(unittest.TestCase):
         return result_state
 
     def assertNextState(self, mortise_state, next_state,
-                        initial_state=None, msg=None):
+                        initial_state=None, msg=None,
+                        enter_next_state=False):
         current_state = mortise_state()
         fake_fsm = FakeFSM(initial_state or {})
         fake_fsm.msg = msg
         result_state = self._next_state(fake_fsm, current_state)
         self.assertIs(result_state, next_state)
+        if enter_next_state:
+            _next_state = next_state()
+            _next_state.on_enter_handler(fake_fsm)
 
     def assertTimedOutState(self, mortise_state, next_state,
                             initial_state=None):


### PR DESCRIPTION
[When building the Manager process state machine]((https://github.com/keyme/kiosk/pull/16561#issuecomment-458643490).), the desire arose to run the `on_enter` method of the `next_state` when calling `assertNextState`.  The idea is that this option allows the maintainers of the state machine to have more granular tests.

These changes have been reflected in the mortise testing examples and were tested in concordance with the commented out code in `tests/manager/process/test_state_machine.py`.

@keyme/control-systems-engineers 