### PR TITLE
Don't call on_leave when returning 'True' from states

### DIFF
--- a/examples/blocking.py
+++ b/examples/blocking.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+import queue
+import random
+import threading
+import time
+
+import mortise
+from mortise import State
+
+
+class Foo(State):
+    def on_enter(self, st):
+        self.count = 0
+
+    def on_state(self, st):
+        if st.msg:
+            print("Foo: ", st.msg['data'])
+            if st.msg['data'] == 'bar':
+                return Bar
+            elif st.msg['data'] == 'foo':
+                self.count += 1
+                print("Foos: {}".format(self.count))
+                return True
+
+    def on_leave(self, st):
+        if st.msg and st.msg['data'] == 'foo':
+            raise Exception("Called on_leave when shouldn't have")
+
+
+class Bar(State):
+    def on_enter(self, st):
+        self.count = 0
+
+    def on_state(self, st):
+        if st.msg:
+            print("Pong: ", st.msg['data'])
+            if st.msg['data'] == 'foo':
+                return Foo
+            elif st.msg['data'] == 'bar':
+                self.count += 1
+                print("Bars: {}".format(self.count))
+                return True
+
+    def on_leave(self, st):
+        if st.msg and st.msg['data'] == 'bar':
+            raise Exception("Called on_leave when shouldn't have")
+
+
+class ErrorState(State):
+    def on_state(self, st):
+        pass
+
+
+def trap_msg(st):
+    print("Trapped: {}".format(st.msg['data']))
+    if st.msg['data'] != 'baz':
+        raise Exception("Only trap 'baz' messages")
+
+
+def loop(msg_queue):
+    # msg_queue should be accessible to another thread which is
+    # handling IPC traffic or otherwise generating events to be
+    # consumed by the state machine
+
+    fsm = mortise.StateMachine(
+        initial_state=Foo,
+        final_state=mortise.DefaultStates.End,
+        default_error_state=ErrorState,
+        msg_queue=msg_queue,
+        log_fn=print,
+        trap_fn=trap_msg)
+
+    # Initial kick of the state machine for setup
+    fsm.tick()
+
+    while True:
+        fsm.tick(msg_queue.get())
+
+
+def msg_loop(msg_queue):
+    # NOTE: The messages consumed by Mortise are content agnostic, the
+    # implementation / checking of message type is up to the user.
+
+    idx = 0
+    while True:
+        messages = ['foo', 'bar', 'baz']
+        idx = random.randint(0, 2)
+        idx %= len(messages)
+        msg_queue.put({'data': messages[idx]})
+        time.sleep(1)
+
+
+def main():
+    msg_queue = queue.Queue()
+    mortise_t = threading.Thread(target=loop, kwargs={'msg_queue': msg_queue})
+    msg_t = threading.Thread(target=msg_loop, kwargs={'msg_queue': msg_queue})
+
+    mortise_t.daemon = True
+    msg_t.daemon = True
+
+    mortise_t.start()
+    msg_t.start()
+
+    mortise_t.join()
+    msg_t.join()
+
+main()

--- a/examples/blocking.py
+++ b/examples/blocking.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
-""" Example for blocking state machine that waits for correct message before
-    moving onto the next state. Also shows an example of using local state
-    values that are reset when the state is re-initialized. """
+""" Example for blocking state machine that waits for the correct messages
+    before moving onto the next state. Also shows an example of using local
+    state values that are reset when the state is re-initialized. """
 
 import queue
 import random

--- a/examples/testing_example.py
+++ b/examples/testing_example.py
@@ -18,6 +18,7 @@ class NextState(mortise.State):
     def on_enter(self, st):
         st.common.entered = True
 
+
 class FirstState2(mortise.State):
     def on_state(self, st):
         if st.common.cool:
@@ -97,6 +98,11 @@ class NoneState(mortise.State):
         return None
 
 
+class TrueState(mortise.State):
+    def on_state(self, st):
+        return True
+
+
 class OnEnterState(mortise.State):
     def on_enter(self, st):
         self.entered = True
@@ -141,6 +147,9 @@ class TestMortise(testing_mortise.MortiseTest):
 
     def testNoTransition(self):
         self.assertNoTransition(NoneState)
+
+    def testTrueNoTransition(self):
+        self.assertNoTransition(TrueState)
 
     def testOnEnter(self):
         self.assertNextState(OnEnterState, NextState)

--- a/mortise/mortise.py
+++ b/mortise/mortise.py
@@ -222,7 +222,7 @@ class State:
 
             # Early exit, this is a wait condition
             if result in BLOCKING_RETURNS:
-                return
+                return result
 
             # If a State intentionally returns itself, this is a retry and
             # we should re-enter on the next tick

--- a/mortise/mortise.py
+++ b/mortise/mortise.py
@@ -2,11 +2,13 @@
 """ mortise is a finite state machine library.
 """
 
-from pprint import pprint
 from threading import Timer
 import collections
 from datetime import datetime
 from queue import Queue
+
+
+BLOCKING_RETURNS = [None, True]
 
 
 class StateRetryLimitError(Exception):
@@ -219,7 +221,7 @@ class State:
             result = self.on_state_handler(shared_state)
 
             # Early exit, this is a wait condition
-            if not result:
+            if result in BLOCKING_RETURNS:
                 return
 
             # If a State intentionally returns itself, this is a retry and
@@ -259,6 +261,7 @@ class DefaultStates:
     class End(State):
         def on_state(self, evt):
             pass
+
 
 class GenericCommon:
     """This is an empty container class to hold any carry-over state in
@@ -511,7 +514,7 @@ class StateMachine:
                     self._is_finished = True
                     self._transition(next_state)
 
-                elif next_state in [None, True]:
+                elif next_state in BLOCKING_RETURNS:
                     # If we didn't return anything at all, or we
                     # returned that we swallowed the message, we'll
                     # assume that the FSM is no longer busy and is

--- a/mortise/testing.py
+++ b/mortise/testing.py
@@ -64,8 +64,9 @@ class MortiseTest(unittest.TestCase):
         return current_state.tick(fake_fsm)
 
     def assertNoTransition(self, mortise_state, initial_state=None, msg=None):
-        self.assertIsNone(
-            self._single_transition(mortise_state, initial_state, msg))
+        self.assertIn(
+            self._single_transition(mortise_state, initial_state, msg),
+            mortise.BLOCKING_RETURNS)
 
     def assertSomeTransition(self, mortise_state, initial_state=None,
                              msg=None):


### PR DESCRIPTION
Fixes an oversight where the `StateMachine` object uses `True` as an accepted return value from the state but the `State` object doesn't. We allow `True` as a return value to show that a looping state did use the message and it shouldn't be passed to the trap function. 

@keyme/control-systems-engineers 