### PR TITLE
 Add functionality to raise exception if possibly stalled 

### DIFF
--- a/examples/blocking.py
+++ b/examples/blocking.py
@@ -17,6 +17,8 @@ class Foo(State):
     """ Foo state keeps count of all "foo" messages it sees and prints out
         the current count. When it sees a "bar" message transitions to Bar
         state. All other messages are ignored and trapped."""
+    TIMEOUT = 10
+
     def on_enter(self, st):
         # Re-initializes Foo count
         self.count = 0
@@ -47,6 +49,8 @@ class Bar(State):
     """ Bar state keeps count of all "bar" messages it sees and prints out
         the current count. When it sees a "foo" message transitions to Foo
         state. All other messages are ignored and trapped."""
+    TIMEOUT = 10
+
     def on_state(self, st):
         if st.msg:
             print("Pong: ", st.msg['data'])

--- a/examples/event_driven.py
+++ b/examples/event_driven.py
@@ -39,17 +39,14 @@ def loop(msg_queue):
         final_state=mortise.DefaultStates.End,
         default_error_state=ErrorState,
         msg_queue=msg_queue,
-        log_fn=print)
+        log_fn=print,
+        dwell_states=[Pong])
 
     # Initial kick of the state machine for setup
     fsm.tick()
 
     while True:
-        try:
-            fsm.tick(msg_queue.get())
-        except mortise.BlockedInUntimedState as err:
-            if not isinstance(err.state, Pong):
-                raise
+        fsm.tick(msg_queue.get())
 
 
 def msg_loop(msg_queue):

--- a/examples/event_driven.py
+++ b/examples/event_driven.py
@@ -9,6 +9,8 @@ from mortise import State
 
 
 class Ping(State):
+    TIMEOUT = 10
+
     def on_state(self, st):
         if st.msg:
             print("Ping: ", st.msg['data'])
@@ -43,7 +45,11 @@ def loop(msg_queue):
     fsm.tick()
 
     while True:
-        fsm.tick(msg_queue.get())
+        try:
+            fsm.tick(msg_queue.get())
+        except mortise.BlockedInUntimedState as err:
+            if not isinstance(err.state, Pong):
+                raise
 
 
 def msg_loop(msg_queue):

--- a/examples/freerun.py
+++ b/examples/freerun.py
@@ -1,16 +1,21 @@
 #!/usr/bin/env python3
-import queue
-
 import mortise
 from mortise import State
 
+
 class Ping(State):
+    RETRIES = 3
+
     def on_enter(self, st):
         print("Entering Ping")
 
     def on_state(self, st):
         print("Ping")
+        return self
+
+    def on_fail(self, st):
         return Pong
+
 
 class Pong(State):
     def on_state(self, st):
@@ -19,6 +24,7 @@ class Pong(State):
 
     def on_leave(self, st):
         print("Leaving Pong")
+
 
 class ErrorState(State):
     def on_state(self, st):

--- a/examples/freerun.py
+++ b/examples/freerun.py
@@ -33,6 +33,6 @@ def main():
         log_fn=print)
 
     # Runs forever
-    fsm.tick()
+    fsm.start_non_blocking()
 
 main()

--- a/mortise/mortise.py
+++ b/mortise/mortise.py
@@ -331,7 +331,8 @@ class StateMachine:
                  on_error_fn=None,
                  log_fn=print,
                  transition_fn=None,
-                 common_state=None):
+                 common_state=None,
+                 dwell_states=None):
 
         # We want to make sure that initial/final/default_err states
         # are descriptors, not instances
@@ -369,6 +370,7 @@ class StateMachine:
         self._trap_fn = trap_fn
 
         self._shared_state = SharedState(self, common_state)
+        self._dwell_states = dwell_states or []
 
         self.reset()
 
@@ -591,5 +593,7 @@ class StateMachine:
         if self.is_finished:
             raise StateMachineComplete()
 
-        if self._msg_queue.empty() and self._current.TIMEOUT is None:
+        if (self._msg_queue.empty() and self._current.TIMEOUT is None
+                and not any([isinstance(self._current, d_state)
+                             for d_state in self._dwell_states])):
             raise BlockedInUntimedState(self._current)

--- a/mortise/mortise.py
+++ b/mortise/mortise.py
@@ -316,6 +316,10 @@ class StateMachine:
     trap will capture any unhandled message and can be used to raise
     exceptions or log notification messages.
 
+    The state machine will raise an error if it stops in a state that has
+    neither a timeout nor is the final state unless it is included in an
+    iterable called dwell_states.
+
     (For a visual overview of the data flow, see mortise_data_flow.png)
 
     Finally, the user MAY supply a common_state class instance. This
@@ -593,6 +597,10 @@ class StateMachine:
         if self.is_finished:
             raise StateMachineComplete()
 
+        # If the state machine hasn't finished and the current state doesn't
+        # have a timeout or isn't in one of the dwell_states passed in when
+        # creating the state machine at the end of a tick an exception is
+        # raised to indicate that the state machine is stalled.
         if (self._msg_queue.empty() and self._current.TIMEOUT is None
                 and not any([isinstance(self._current, d_state)
                              for d_state in self._dwell_states])):

--- a/mortise/mortise.py
+++ b/mortise/mortise.py
@@ -490,8 +490,10 @@ class StateMachine:
 
     def start_non_blocking(self):
         self._msg_queue.put(None)
+        # Still need while loop for getting errors pushed into queue
         while True:
             try:
+                # Still check messages for RetryLimitException
                 msg = self._msg_queue.get()
                 self.tick(msg)
             except StateMachineComplete:


### PR DESCRIPTION
There are two changes here. The first is adding a function to replace `tick` for non-blocking state machines which raises an exception if the state machine finishes without completing. If also runs the state machine while supporting retry counts for non-blocking state machines which just calling a single `tick` will not support. 

The other change is to raise an exception in blocking state machine (in `tick`) if the state we are blocking in doesn't have a timeout value set and we could stall indefinitely. This change does break current kiosk software. As shown in the `event_driven.py` example, untimed states can still be used but checked to make sure you only have expected indefinite states. 

Addresses https://keymeinc.atlassian.net/browse/CS-98

@keyme/control-systems-engineers 