### PR TITLE
Fix passing StateMachineComplete to error_fn

### DIFF
--- a/mortise/mortise.py
+++ b/mortise/mortise.py
@@ -548,9 +548,6 @@ class StateMachine:
                     # waiting on some external message to move the
                     # state along
 
-                    if self.is_finished:
-                        raise StateMachineComplete()
-
                     fsm_busy = False
 
                     # Additionally, if there is a message, and we


### PR DESCRIPTION
We will raise `StateMachineComplete` below anyway and doing it in the main loop is causing it to be passed to the error handling function. 

@keyme/control-systems-engineers 